### PR TITLE
chore: ライセンス情報を追加

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,5 +10,7 @@ layers:
     path: build
     name: poppler-aws-lambda-layer
     description: Poppler v20.10.0
+    licenseInfo: GPL-2.0-or-later
+    retain: true
     package:
       artifact: build/artifacts.zip


### PR DESCRIPTION
Serverless FrameworkからLayerのライセンス情報を追加できたので、追加しました。
AWS LambdaのConsoleに表示されるようになります。

また、Layerのバージョンを保持しておかないと、利用しているStackをRollbackする際に、対応するバージョンが消失していて戻せないということが起こるので、 `retain: true` を指定するように変更します。